### PR TITLE
Allow ModelAdmin to exclude some fields from mass-modification

### DIFF
--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -119,6 +119,9 @@ class MassAdmin(admin.ModelAdmin):
         model = self.model
         opts = model._meta
         general_error = None
+
+        # Allow model to hide some fields for mass admin
+        self.exclude = getattr(self.admin_obj, "massadmin_exclude", None)
                         		
         object_ids = comma_separated_object_ids.split(',')
         object_id = object_ids[0]


### PR DESCRIPTION
Introduces massadmin_exclude field of specific model ModelAdmin, that could be set to exclude some fields from mass-modification.

Example usage:

``` python
class PollAdmin(admin.ModelAdmin):
    massadmin_exclude = ['user', ]
```
