### PR TITLE
Add for massadmin_queryset on the ModelAdmin being edited

### DIFF
--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -122,12 +122,13 @@ class MassAdmin(admin.ModelAdmin):
 
         # Allow model to hide some fields for mass admin
         exclude_fields = getattr(self.admin_obj, "massadmin_exclude", ())
+        queryset = getattr(self.admin_obj, "massadmin_queryset", self.queryset)(request)
                         		
         object_ids = comma_separated_object_ids.split(',')
         object_id = object_ids[0]
 
         try:
-            obj = self.queryset(request).get(pk=unquote(object_id))
+            obj = queryset.get(pk=unquote(object_id))
         except model.DoesNotExist:
             obj = None
 
@@ -148,7 +149,7 @@ class MassAdmin(admin.ModelAdmin):
                 try:
                     objects_count = 0
                     changed_count = 0
-                    objects = self.queryset(request).filter(pk__in = object_ids)
+                    objects = queryset.filter(pk__in = object_ids)
                     for obj in objects:
                         objects_count += 1
                         form = ModelForm(request.POST, request.FILES, instance=obj)


### PR DESCRIPTION
I have run into a situation where the mass admin is slowed down by fetching related objects one at a time. This includes fields that are not being edited.

I believe the standard way to alleviate this problem is to use `select_related`. When you need `select_related` for the admin, you override `ModelAdmin.queryset`. So I have mimicked the pattern used for `massadmin_exclude` and added the capability to override the default queryset by defining a `massadmin_queryset` method on a `ModelAdmin`.

Perhaps the code is even simpler than my explanation...
