### PR TITLE
Removing slash for coherence with the link itself - was 404 when Django ...

### DIFF
--- a/massadmin/urls.py
+++ b/massadmin/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import *
 
 urlpatterns = patterns('',
-    (r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[0-9,]+)/$',
+    (r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[0-9,]+)$',
      'massadmin.massadmin.mass_change_view'),
 )


### PR DESCRIPTION
...was set not to add that slash automatically
