### PR TITLE
Allow alphanumeric primary keys on urls

### DIFF
--- a/massadmin/urls.py
+++ b/massadmin/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import *
 
 urlpatterns = patterns('',
-    (r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[\w,]+)$',
+    (r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[\w,\.]+)$',
      'massadmin.massadmin.mass_change_view'),
 )

--- a/massadmin/urls.py
+++ b/massadmin/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import *
 
 urlpatterns = patterns('',
-    (r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[0-9,]+)$',
+    (r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[\w,]+)$',
      'massadmin.massadmin.mass_change_view'),
 )


### PR DESCRIPTION
If the primary key is a CharField or SlugField, massadmin will raise 404 in some pages, I fixed it