### PR TITLE
Django 1.10 compatibility fixes

### DIFF
--- a/mass_demo/settings.py
+++ b/mass_demo/settings.py
@@ -22,7 +22,27 @@ SECRET_KEY = '0)4mwt=!3*dvff#a($-ii3(hf461c%upq@ha21qj7o#m=_*xms'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATE_DEBUG = True
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            'debug': True,
+        },
+    },
+]
+
 
 ALLOWED_HOSTS = []
 

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -54,7 +54,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.http import Http404, HttpResponseRedirect
 from django.utils.html import escape
 from django import template
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.forms.formsets import all_valid
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 
@@ -163,10 +163,9 @@ class MassAdmin(admin.ModelAdmin):
             'save_as': self.save_as,
             'save_on_top': self.save_on_top,
         })
-        context_instance = template.RequestContext(
+        request.current_app = self.admin_site.name
+        return render(
             request,
-            current_app=self.admin_site.name)
-        return render_to_response(
             self.change_form_template or [
                 "admin/%s/%s/mass_change_form.html" %
                 (app_label,
@@ -174,8 +173,7 @@ class MassAdmin(admin.ModelAdmin):
                 "admin/%s/mass_change_form.html" %
                 app_label,
                 "admin/mass_change_form.html"],
-            context,
-            context_instance=context_instance)
+            context)
 
     def mass_change_view(
             self,
@@ -318,7 +316,11 @@ class MassAdmin(admin.ModelAdmin):
 
         # We don't want the user trying to mass change unique fields!
         unique_fields = []
-        for field_name in model._meta.get_all_field_names():
+        try:  # Django >= 1.9
+            fields = model._meta.get_fields()
+        except:
+            fields = model._meta.get_all_field_names()
+        for field_name in fields:
             try:
                 field = model._meta.get_field(field_name)
                 if field.unique:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -6,7 +6,26 @@ SECRET_KEY = uuid4().hex
 
 DEBUG = True
 
-TEMPLATE_DEBUG = True
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            'debug': True,
+        },
+    },
+]
 
 INSTALLED_APPS = (
     'django.contrib.admin',


### PR DESCRIPTION
I gave it little bit more time and solved all remaining compatibility issues. Tests are running in Django 1.6-1.10 without much effort, so no need for dropping backward compatibility.