### PR TITLE
Allow massadmin to be used with a custom AdminSite

### DIFF
--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -77,9 +77,9 @@ def mass_change_selected(modeladmin, request, queryset):
 mass_change_selected.short_description = _('Mass Edit')
 
 
-def mass_change_view(request, app_name, model_name, object_ids):
+def mass_change_view(request, app_name, model_name, object_ids, admin_site=None):
     model = get_model(app_name, model_name)
-    ma = MassAdmin(model, admin.site)
+    ma = MassAdmin(model, admin_site or admin.site)
     return ma.mass_change_view(request, object_ids)
 mass_change_view = staff_member_required(mass_change_view)
 


### PR DESCRIPTION
Django allows customization of AdminSites, as described in https://docs.djangoproject.com/en/1.9/ref/contrib/admin/#customizing-adminsite
This patch allows massadmin to work with a custom AdminSite by passing the custom site to the view (it is also necessary to add the mass_change_selected action to the custom site):

```
from massadmin import mass_change_selected

admin_site = MyCustomAdminSite(name='custom_admin')
admin_site.add_action(mass_change_selected)

url(r'^admin/', include(massadmin.urls), kwargs={'admin_site': admin_site}),
```
