### PR TITLE
Use session to store long objects_ids string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.5"
 env:
   - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.7,<1.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "2.7"
   - "3.5"
 env:
-  - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.7,<1.8"
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
@@ -21,3 +20,6 @@ after_success:
 matrix:
   allow_failures:
      - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
+  exclude:
+    - python: "3.5"
+      env: DJANGO="Django>=1.7,<1.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ script:
   - coverage run --source=massadmin manage.py test --settings=tests.settings
 after_success:
   coveralls
-sudo: false
 matrix:
   allow_failures:
      - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.5
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code

--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ See [Django Docs on the subject](https://docs.djangoproject.com/en/dev/ref/contr
 This project could use some love. It has few unit test and old code that could be refactored.
 When you make a pull request - please include a unit test. 
 If you want to take on improving the project let me know by opening an issue.
+
+New maintainers welcome. I (bufke) will only be providing minimal support to keep the project running on modern versions of Django. Open an issue if you are interested.
+
+# Changelog
+
+2.6 - Added Django 1.10 support

--- a/mass_demo/settings.py
+++ b/mass_demo/settings.py
@@ -22,7 +22,27 @@ SECRET_KEY = '0)4mwt=!3*dvff#a($-ii3(hf461c%upq@ha21qj7o#m=_*xms'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATE_DEBUG = True
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            'debug': True,
+        },
+    },
+]
+
 
 ALLOWED_HOSTS = []
 

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -75,7 +75,7 @@ def mass_change_selected(modeladmin, request, queryset):
 def get_mass_change_redirect_url(model_meta, pk_list, session):
     object_ids = ",".join(str(s) for s in pk_list)
     if len(object_ids) > 500:
-        hash_id = "session-%s" % hashlib.md5(object_ids).hexdigest()
+        hash_id = "session-%s" % hashlib.md5(object_ids.encode('utf-8')).hexdigest()
         session[hash_id] = object_ids
         session.save()
         object_ids = hash_id

--- a/massadmin/urls.py
+++ b/massadmin/urls.py
@@ -3,7 +3,7 @@ from .massadmin import mass_change_view
 
 
 urlpatterns = [
-    url(r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[\w,\.]+)/$',
+    url(r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[\w,\.\-]+)/$',
      mass_change_view,
      name='massadmin_change_view'),
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "django-mass-edit",
-    version = "2.6",
+    version = "2.7",
     author = "David Burke",
     author_email = "david@burkesoftware.com",
     description = ("Make bulk changes in the Django admin interface"),
@@ -17,7 +17,7 @@ setup(
         'Framework :: Django',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         "License :: OSI Approved :: BSD License",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -6,7 +6,26 @@ SECRET_KEY = uuid4().hex
 
 DEBUG = True
 
-TEMPLATE_DEBUG = True
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            'debug': True,
+        },
+    },
+]
 
 INSTALLED_APPS = (
     'django.contrib.admin',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,20 +3,17 @@ from django.contrib.auth.models import User
 from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from massadmin.massadmin import MassAdmin
+from massadmin.massadmin import MassAdmin, get_mass_change_redirect_url
 
 from .admin import CustomAdminForm, BaseAdmin, InheritedAdmin
 from .models import CustomAdminModel, InheritedAdminModel
 
 
-def get_massadmin_url(objects):
+def get_massadmin_url(objects,session):
     if not hasattr(objects, "__iter__"):
         objects = [objects]
     opts = objects[0]._meta
-    return reverse("massadmin_change_view",
-                   kwargs={"app_name": opts.app_label,
-                           "model_name": opts.model_name,
-                           "object_ids": ",".join(str(o.pk) for o in objects)})
+    return get_mass_change_redirect_url(opts,[o.pk for o in objects],session)
 
 
 def get_changelist_url(model):
@@ -33,14 +30,20 @@ class AdminViewTest(TestCase):
         self.client.login(username='temporary', password='temporary')
 
     def test_massadmin_form_generation(self):
-        response = self.client.get(get_massadmin_url(self.user))
+        response = self.client.get(get_massadmin_url(self.user, self.client.session))
         self.assertContains(response, 'First name')
+
+    def test_massadmin_form_generation_with_many_objects(self):
+        models = [CustomAdminModel.objects.create(name="model {}".format(i))
+                  for i in range(0, 2000)]
+        response = self.client.get(get_massadmin_url(models, self.client.session))
+        self.assertContains(response, 'Change custom admin model')
 
     def test_update(self):
         models = [CustomAdminModel.objects.create(name="model {}".format(i))
                   for i in range(0, 3)]
 
-        response = self.client.post(get_massadmin_url(models),
+        response = self.client.post(get_massadmin_url(models, self.client.session),
                                     {"_mass_change": "name",
                                      "name": "new name"})
         self.assertRedirects(response, get_changelist_url(CustomAdminModel))
@@ -76,7 +79,7 @@ class AdminViewTest(TestCase):
         models = [CustomAdminModel.objects.create(name="model {}".format(i))
                   for i in range(0, 3)]
 
-        response = self.client.post(get_massadmin_url(models),
+        response = self.client.post(get_massadmin_url(models, self.client.session),
                                     {"_mass_change": "name",
                                      "name": "invalid {}".format(models[-1].pk)})
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
When many objects are selected for mass edit the URL string can get very long, especially if the model's primary key has many digits or id a uuid.
At some point the URL becomes too long and this will result in a server error.

My solution checks if the object_ids string is over 500 characters (We might want to have that number configurable) and if it is so stores the comma separated string in the request session instead of passing it along.
