### PR TITLE
Some love

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+include =
+    massadmin/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 settings_local.py
 django_mass_edit.egg-info
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 settings_local.py
+django_mass_edit.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 settings_local.py
 django_mass_edit.egg-info
 .idea
+.coverage
+.tox

--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ See [Django Docs on the subject](https://docs.djangoproject.com/en/dev/ref/contr
         url(r'^admin/', include(massadmin.urls), kwargs={'admin_site': admin_site}),
         ```
 
+## Settings
+
+By default, all models registered in the admin will get `Mass Edit` action.
+
+If you wish to disable this, add this to settings file:ž
+
+``` python
+MASSEDIT = {
+    'ADD_ACTION_GLOBALLY': False,
+}
+``` 
+
+Then, to add the mass edit action to specific models, use the provided mixin:
+``` python
+from massedit.massedit import MassEditMixin
+
+class MyModelAdmin(MassEditMixin, admin.ModelAdmin):
+    ...
+``` 
+
 
 # Hacking and pull requests
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Image was taken using Grappelli
 
 1. `pip install django-mass-edit`
 2. In `settings.py`, add `massadmin` to `INSTALLED_APPS`
-3. In `settings.py`, uncomment/add `django.template.loaders.eggs.Loader` in `TEMPLATE_LOADERS` section
-4. Add `url(r'^admin/', include("massadmin.urls")),` to `urls.py`
+3. Add `path(r'admin/', include('massadmin.urls')),` to `urls.py` before `admin.site.urls` line 
 
 ## Optional
 You may exclude some fields like this:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ See [Django Docs on the subject](https://docs.djangoproject.com/en/dev/ref/contr
 
 ## Settings
 
+### Enable Mass Edit for specific models
+
 By default, all models registered in the admin will get `Mass Edit` action.
 
 If you wish to disable this, add this to settings file:ž
@@ -69,6 +71,33 @@ from massedit.massedit import MassEditMixin
 class MyModelAdmin(MassEditMixin, admin.ModelAdmin):
     ...
 ``` 
+
+### Session-based URLs
+
+Django-mass-edit will keep IDs for selected objects in URL, e.g:
+```
+/admin/myapp/mymodel-masschange/1,2,3,4,5/
+```
+
+To avoid problems with too long URL when editing large number of objects, 
+the list of objects will be stored in session and the URL will look like this:
+```
+/admin/myapp/mymodel-masschange/session-c81e728d9d4c2f636f067f89cc14862c/
+```
+(same length regardless of the number of selected objects).
+
+The default threshold is 500 characters for the IDs in the URL, not counting 
+anything before or after the the IDs.
+
+This threshold can be changed in settings:
+
+``` python
+MASSEDIT = {
+    'SESSION_BASED_URL_THRESHOLD': 10,
+}
+``` 
+
+To always use the session-based URLs, simply put in value `0`.
 
 
 # Hacking and pull requests

--- a/mass_demo/settings.py
+++ b/mass_demo/settings.py
@@ -60,7 +60,7 @@ INSTALLED_APPS = (
     'tests'
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/mass_demo/urls.py
+++ b/mass_demo/urls.py
@@ -4,6 +4,6 @@ from massadmin import urls as massadmin_urls
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^admin/', include(massadmin_urls)),
 ]

--- a/massadmin/apps.py
+++ b/massadmin/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 from django.contrib import admin
+from . import settings
+
 
 class MassAdminConfig(AppConfig):
     name = 'massadmin'
@@ -8,4 +10,5 @@ class MassAdminConfig(AppConfig):
     def ready(self):
         from .massadmin import mass_change_selected
 
-        admin.site.add_action(mass_change_selected)
+        if settings.ADD_ACTION_GLOBALLY:
+            admin.site.add_action(mass_change_selected)

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -376,3 +376,9 @@ class MassAdmin(admin.ModelAdmin):
             context,
             change=True,
             obj=obj)
+
+
+class MassEditMixin:
+    actions = (
+        mass_change_selected,
+    )

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -1,5 +1,5 @@
 # Updates by David Burke <david@burkesoftware.com>
-# Orginal code is at
+# Original code is at
 # http://algoholic.eu/django-mass-change-admin-site-extension/
 """
 Copyright (c) 2010, Stanislaw Adaszewski
@@ -37,7 +37,7 @@ try:
     from django.urls import reverse
 except ImportError:  # Django<2.0
     from django.core.urlresolvers import reverse
-from django.db import transaction, models
+from django.db import transaction
 try:  # Django>=1.9
     from django.apps import apps
     get_model = apps.get_model
@@ -57,7 +57,6 @@ from django.utils.safestring import mark_safe
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import Http404, HttpResponseRedirect
 from django.utils.html import escape
-from django import template
 from django.shortcuts import render
 from django.forms.formsets import all_valid
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
@@ -102,6 +101,7 @@ def mass_change_view(request, app_name, model_name, object_ids, admin_site=None)
     ma = MassAdmin(model, admin_site or admin.site)
     return ma.mass_change_view(request, object_ids)
 mass_change_view = staff_member_required(mass_change_view)
+
 
 def get_formsets(model, request, obj=None):
     try:  # Django>=1.9

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -62,6 +62,8 @@ from django.shortcuts import render
 from django.forms.formsets import all_valid
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 
+from . import settings
+
 
 def mass_change_selected(modeladmin, request, queryset):
     selected = queryset.values_list('pk', flat=True)
@@ -77,7 +79,7 @@ def mass_change_selected(modeladmin, request, queryset):
 
 def get_mass_change_redirect_url(model_meta, pk_list, session):
     object_ids = ",".join(str(s) for s in pk_list)
-    if len(object_ids) > 500:
+    if len(object_ids) > settings.SESSION_BASED_URL_THRESHOLD:
         hash_id = "session-%s" % hashlib.md5(object_ids.encode('utf-8')).hexdigest()
         session[hash_id] = object_ids
         session.save()

--- a/massadmin/settings.py
+++ b/massadmin/settings.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+
+
+_default_settings = {
+    'ADD_ACTION_GLOBALLY': True,
+}
+
+_settings = getattr(settings, 'MASSEDIT', _default_settings)
+
+ADD_ACTION_GLOBALLY = _settings.get(
+    'ADD_ACTION_GLOBALLY', _default_settings['ADD_ACTION_GLOBALLY'])

--- a/massadmin/settings.py
+++ b/massadmin/settings.py
@@ -3,9 +3,14 @@ from django.conf import settings
 
 _default_settings = {
     'ADD_ACTION_GLOBALLY': True,
+    'SESSION_BASED_URL_THRESHOLD': 500,
 }
 
 _settings = getattr(settings, 'MASSEDIT', _default_settings)
 
 ADD_ACTION_GLOBALLY = _settings.get(
     'ADD_ACTION_GLOBALLY', _default_settings['ADD_ACTION_GLOBALLY'])
+
+
+SESSION_BASED_URL_THRESHOLD = _settings.get(
+    'SESSION_BASED_URL_THRESHOLD', _default_settings['SESSION_BASED_URL_THRESHOLD'])

--- a/massadmin/settings.py
+++ b/massadmin/settings.py
@@ -8,9 +8,10 @@ _default_settings = {
 
 _settings = getattr(settings, 'MASSEDIT', _default_settings)
 
-ADD_ACTION_GLOBALLY = _settings.get(
-    'ADD_ACTION_GLOBALLY', _default_settings['ADD_ACTION_GLOBALLY'])
+
+def _get_value(name):
+    return _settings.get(name, _default_settings[name])
 
 
-SESSION_BASED_URL_THRESHOLD = _settings.get(
-    'SESSION_BASED_URL_THRESHOLD', _default_settings['SESSION_BASED_URL_THRESHOLD'])
+ADD_ACTION_GLOBALLY = _get_value('ADD_ACTION_GLOBALLY')
+SESSION_BASED_URL_THRESHOLD = _get_value('SESSION_BASED_URL_THRESHOLD')

--- a/massadmin/templates/admin/includes/mass_fieldset.html
+++ b/massadmin/templates/admin/includes/mass_fieldset.html
@@ -47,7 +47,7 @@
               <input type="checkbox" class="update_checkbox" name="_mass_change" value="{{ field.field.name }}"
                 {% if field.field.name in mass_changes_fields %}checked{% endif %} />
             </td>
-            <td>
+            <td class="form-row field-{{ field.field.name }}">
               {% if field.is_checkbox %}
                 {{ field.field }}{{ field.label_tag }}
               {% else %}

--- a/massadmin/urls.py
+++ b/massadmin/urls.py
@@ -3,7 +3,7 @@ from .massadmin import mass_change_view
 
 
 urlpatterns = [
-    url(r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[\w,\.\-]+)/$',
+    url(r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)/masschange/(?P<object_ids>[\w,\.\-]+)/$',
      mass_change_view,
      name='massadmin_change_view'),
 ]

--- a/massadmin/urls.py
+++ b/massadmin/urls.py
@@ -3,7 +3,7 @@ from .massadmin import mass_change_view
 
 
 urlpatterns = [
-    url(r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)/masschange/(?P<object_ids>[\w,\.\-]+)/$',
+    url(r'(?P<app_name>[^/]+)/(?P<model_name>[^/]+)-masschange/(?P<object_ids>[\w,\.\-]+)/$',
      mass_change_view,
      name='massadmin_change_view'),
 ]

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -20,8 +20,10 @@ class CustomAdminForm(forms.ModelForm):
         fields = ("name", )
         model = CustomAdminModel
 
+
 class InheritedAdminInline(admin.TabularInline):
     model = InheritedAdminModel
+
 
 class CustomAdmin(admin.ModelAdmin):
     inlines = [InheritedAdminInline, ]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -97,7 +97,7 @@ class CustomizationTestCase(TestCase):
     """
 
     def test_custom_from(self):
-        """ If form is overrided in ModelAdmin, it should be overrided in
+        """ If form is overridden in ModelAdmin, it should be overridden in
         MassAdmin too.
         """
         ma = MassAdmin(CustomAdminModel, admin.site)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,7 @@
 from six.moves.urllib import parse
 from django.contrib.auth.models import User
 from django.contrib import admin
-from django.test import TestCase
+from django.test import TestCase, override_settings
 try:
     from django.urls import reverse
 except ImportError:  # Django<2.0
@@ -39,6 +39,13 @@ class AdminViewTest(TestCase):
     def test_massadmin_form_generation_with_many_objects(self):
         models = [CustomAdminModel.objects.create(name="model {}".format(i))
                   for i in range(0, 2000)]
+        response = self.client.get(get_massadmin_url(models, self.client.session))
+        self.assertContains(response, 'Change custom admin model')
+
+    @override_settings(MASSEDIT={'SESSION_BASED_URL_THRESHOLD': 3})
+    def test_massadmin_form_generation_with_many_objects_settings(self):
+        models = [CustomAdminModel.objects.create(name="model {}".format(i))
+                  for i in range(0, 2)]
         response = self.client.get(get_massadmin_url(models, self.client.session))
         self.assertContains(response, 'Change custom admin model')
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist =
+    py{27,34,35}-dj{18,19,110}
+    py{27,34,35,36,37}-dj111
+    py{34,35,36,37}-dj20
+    py{35,36,37}-dj{21,22,master}
+
+[testenv]
+commands =
+    {envpython} --version
+    - coverage erase
+    coverage run manage.py test {posargs}
+    - coverage report
+deps =
+    -r{toxinidir}/requirements.txt


### PR DESCRIPTION
A bit of love for the project ❤️ 

## New settings

django-mass-edit will now read `MASSEDIT` dict from project settings.

This are the defaults, not changing the current behavior:

``` python
MASSEDIT = {
    'ADD_ACTION_GLOBALLY': True,
    'SESSION_BASED_URL_THRESHOLD': 500,
}
```

### Not adding the action to allthethings

`'ADD_ACTION_GLOBALLY': False` will prevent adding `Mass Edit` action to all models automatically.
There is a tiny admin mixin added to do that manually for each model where desired.

### Always use session-based URLs

Well, technically the change is to move the hardcoded `500` into settings, but I'm using 
`'SESSION_BASED_URL_THRESHOLD': 0`, i.e. simply always using the session-based settings.

While 500 is a sensible default, since it only applies to the ids portion of the URL, sometimes other parts of the URL can make the total length spill over the limit (2k chars or something thereabout I think).


## Compatibility with django-filer

The change `class="form-row field-{{ field.field.name }}` makes it compatible with [django-filter](https://github.com/carltongibson/django-filter). Just for some styles to catch on, already worked otherwise.

## Tox

Added tox ¯\\\_(ツ)\_/¯

## Some typos and coding style

Not much, just a few details here and there...

## Readme

Removed the step about adding `eggs.Loader` to `TEMPLATE_LOADERS`, not needed any more.

Also explained the new settings.
