### PR TITLE
Custom Admin: Mass edit not working due to bad reverse

### DIFF
--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -149,7 +149,8 @@ class MassAdmin(admin.ModelAdmin):
             'obj': force_text(obj)}
 
         self.message_user(request, msg)
-        redirect_url = reverse('admin:{}_{}_changelist'.format(
+        redirect_url = reverse('{}:{}_{}_changelist'.format(
+            self.admin_site.name,
             self.model._meta.app_label,
             self.model._meta.model_name,
         ))

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -44,3 +44,6 @@ class InheritedAdmin(BaseAdmin):
 
 
 admin.site.register(InheritedAdminModel, InheritedAdmin)
+
+custom_admin_site = admin.AdminSite(name='myadmin')
+custom_admin_site.register(CustomAdminModel, CustomAdmin)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -19,10 +19,10 @@ def get_massadmin_url(objects,session):
     return get_mass_change_redirect_url(opts,[o.pk for o in objects],session)
 
 
-def get_changelist_url(model):
+def get_changelist_url(model, admin_name='admin'):
     opts = model._meta
-    return reverse("admin:{}_{}_changelist".format(
-        opts.app_label, opts.model_name))
+    return reverse("{}:{}_{}_changelist".format(
+        admin_name, opts.app_label, opts.model_name))
 
 
 class AdminViewTest(TestCase):
@@ -49,17 +49,23 @@ class AdminViewTest(TestCase):
         response = self.client.get(get_massadmin_url(models, self.client.session))
         self.assertContains(response, 'Change custom admin model')
 
-    def test_update(self):
+    def test_update(self, admin_name='admin'):
         models = [CustomAdminModel.objects.create(name="model {}".format(i))
                   for i in range(0, 3)]
 
         response = self.client.post(get_massadmin_url(models, self.client.session),
                                     {"_mass_change": "name",
                                      "name": "new name"})
-        self.assertRedirects(response, get_changelist_url(CustomAdminModel))
+        self.assertRedirects(response, get_changelist_url(CustomAdminModel, admin_name))
         new_names = CustomAdminModel.objects.order_by("pk").values_list("name", flat=True)
         # all models have changed
         self.assertEqual(list(new_names), ["new name"] * 3)
+
+    @override_settings(ROOT_URLCONF='tests.urls_custom_admin')
+    def test_custom_admin_site_update(self):
+        """ We test_update for a custom admin on top of a regular as well
+        """
+        self.test_update('myadmin')
 
     def test_preserve_filters(self):
         """ Preserve filters which was choosed in lookup form

--- a/tests/urls_custom_admin.py
+++ b/tests/urls_custom_admin.py
@@ -1,0 +1,15 @@
+"""
+Used in tests.tests.test_custom_admin_site_update
+Make sure the package works with a custom admin on top of a regular admin
+"""
+from django.conf.urls import include, url
+from django.contrib import admin
+from massadmin import urls as massadmin_urls
+from .admin import custom_admin_site
+admin.autodiscover()
+
+urlpatterns = [
+    url(r'^admin/', admin.site.urls),
+    url(r'^custom_admin_path/', custom_admin_site.urls),
+    url(r'^custom_admin_path/', include(massadmin_urls), kwargs={'admin_site': custom_admin_site}),
+]


### PR DESCRIPTION
- Fix mass edit not working with a custom admin namespace (happens when several admins)
- Add unit test

I've add a unit test for the previously failing case.
I didn't find a way to write it without adding a new url file.. 