### PR TITLE
user group restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [Django Docs on the subject](https://docs.djangoproject.com/en/dev/ref/contr
 
 ### Enable Mass Edit for specific models
 
-By default, all models registered in the admin will get `Mass Edit` action.
+By default, all models registered in the admin will get `Mass Edit` action, for all site users.
 
 If you wish to disable this, add this to settings file:
 
@@ -71,6 +71,19 @@ from massadmin.massadmin import MassEditMixin
 class MyModelAdmin(MassEditMixin, admin.ModelAdmin):
     ...
 ``` 
+
+### Restrict Mass actions enabled users
+
+You can restrict Mass edit action to those users belonging to a specified group name.
+
+``` python
+MASSEDIT = {
+    'ADD_ACTION_GLOBALLY': False,
+    'MASS_USERS_GROUP': 'somegroup'
+}
+``` 
+
+Note that user user restriction has effect only in conjunction with 'ADD_ACTION_GLOBALLY' variable set to false.
 
 ### Session-based URLs
 

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -387,7 +387,16 @@ class MassAdmin(admin.ModelAdmin):
             obj=obj)
 
 
-class MassEditMixin:
-    actions = (
-        mass_change_selected,
-    )
+class MassEditMixin(object):
+
+    def get_actions(self, request):
+        actions = super(MassEditMixin, self).get_actions(request)
+
+        if settings.MASS_USERS_GROUP and settings.MASS_USERS_GROUP in [g.name for g in request.user.groups.all()]:
+            actions[mass_change_selected.__name__] = (
+                mass_change_selected,
+                mass_change_selected.__name__,
+                mass_change_selected.short_description
+            )
+
+        return actions

--- a/massadmin/settings.py
+++ b/massadmin/settings.py
@@ -4,6 +4,7 @@ from django.conf import settings
 _default_settings = {
     'ADD_ACTION_GLOBALLY': True,
     'SESSION_BASED_URL_THRESHOLD': 500,
+    'MASS_USERS_GROUP': None,
 }
 
 _settings = getattr(settings, 'MASSEDIT', _default_settings)
@@ -15,3 +16,4 @@ def _get_value(name):
 
 ADD_ACTION_GLOBALLY = _get_value('ADD_ACTION_GLOBALLY')
 SESSION_BASED_URL_THRESHOLD = _get_value('SESSION_BASED_URL_THRESHOLD')
+MASS_USERS_GROUP = _get_value('MASS_USERS_GROUP')


### PR DESCRIPTION
Hi, thanks for your handy app.
With the PR I'm suggesting to limit the availability of 'Mass edit' action only to users belonging to a specified group.
Mass Edit action could be very dangerous and sometimes should be perfomed only by conscious users.

Best Regards.
Enrico