### PR TITLE
mass_edit_view() should call get_form() on admin_obj

### DIFF
--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -238,7 +238,7 @@ class MassAdmin(admin.ModelAdmin):
                         opts.verbose_name),
                     'key': escape(object_id)})
 
-        ModelForm = self.get_form(request, obj)
+        ModelForm = self.admin_obj.get_form(request, obj)
         formsets = []
         errors, errors_list = None, None
         mass_changes_fields = request.POST.getlist("_mass_change")

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -42,8 +42,16 @@ class CustomAdminWithCustomTemplate(admin.ModelAdmin):
     change_form_template = "admin/change_form_template.html"
 
 
-class CustomAdminWithGetFieldsets(admin.ModelAdmin):
+class CustomAdminWithGetFieldsetsAncestor(admin.ModelAdmin):
+    """
+    Ancestor that defines fieldsets
+    which should not be used by the mass_change_view()
+    """
     model = FieldsetsAdminModel
+    fieldsets = ()
+
+
+class CustomAdminWithGetFieldsets(CustomAdminWithGetFieldsetsAncestor):
 
     def get_fieldsets(self, request, obj=None):
         return (


### PR DESCRIPTION
@pedrovhb I just bumped into #103 issue myself. Thank you for that fix.

I just realized, that it is not enough - the `get_form()` function should be called also from `admin_obj`, otherwise it will pick up the wrong `get_fieldsets()` and run into problems later during rendering.

Similar applies also for `get_queryset()` fixed in #111