### PR TITLE
Track errors across all forms and provide feedback via messages to user.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ django_mass_edit.egg-info
 .idea
 .coverage
 .tox
+.spyproject

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -37,7 +37,7 @@ try:
     from django.urls import reverse
 except ImportError:  # Django<2.0
     from django.core.urlresolvers import reverse
-from django.db import transaction, DatabaseError
+from django.db import transaction, DatabaseError, IntegrityError
 try:  # Django>=1.9
     from django.apps import apps
     get_model = apps.get_model
@@ -313,6 +313,12 @@ class MassAdmin(admin.ModelAdmin):
                                     new_object,
                                     change_message)
                                 changed_count += 1
+
+                            except IntegrityError:
+                                msg = f'<p>Cannot add {str(new_object)}: '\
+                                    'it already exists in the datebase</p>'
+                                messages.add_message(
+                                    request, messages.ERROR, mark_safe(msg))
 
                             except DatabaseError as err:
                                 detail = str(err.__cause__ or '')

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -298,8 +298,8 @@ class MassAdmin(admin.ModelAdmin):
 
                         if all_valid(formsets) and form_validated:
                             # self.admin_obj.save_model(request, new_object, form, change=True)
-                            #  second atomic to prevent :
-                            # " You can't execute queries ..." error
+                            #  second transaction.atomic added to avoid:
+                            #  "You can't execute queries ..." error
                             with transaction.atomic():
 
                                 try:
@@ -327,8 +327,11 @@ class MassAdmin(admin.ModelAdmin):
 
                                 except IntegrityError:
                                     obj_url = url_to_edit_object(obj)
-                                    msg = f'<p>Cannot modify {obj_url}: '\
-                                        'a record already exists in the database</p>'
+                                    hint = '(Either run the mass edit without'\
+                                        ' this; or remove the existing record)'
+                                    msg = f'<p>Cannot modify {obj_url}: a '\
+                                        'record already exists in the database'\
+                                        f' {hint}</p>'
                                     messages.add_message(
                                         request, messages.ERROR, mark_safe(msg))
 

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -315,7 +315,8 @@ class MassAdmin(admin.ModelAdmin):
                                 changed_count += 1
 
                             except DatabaseError as err:
-                                msg = f'<p>Cannot add {new_object}: {err.message}</p>'
+                                detail = str(err.__cause__ or '')
+                                msg = f'<p>Cannot add {new_object}: {detail}</p>'
                                 messages.add_message(
                                     request, messages.ERROR, mark_safe(msg))
 

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -305,7 +305,7 @@ class MassAdmin(admin.ModelAdmin):
                                         formset,
                                         change=True)
                             except DatabaseError as err:
-                                forms_errors.append({new_object: err.message})
+                                forms_errors.append({new_object: err})
 
                             change_message = self.construct_change_message(
                                 request,

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -66,8 +66,9 @@ from . import settings
 
 def url_to_edit_object(obj):
     url = reverse('admin:%s_%s_change' % (
-        obj._meta.app_label, obj._meta.model_name), args=[obj.id])
-    return '<a href="%s" target="_">%s</a>' % (url,  obj.__unicode__())
+        obj._meta.app_label, obj._meta.model_name), args=[obj.pk])
+    return '<a href="%s" target="_">%s #%s</a>' % (
+        url, obj._meta.model_name, obj.pk)
 
 
 def mass_change_selected(modeladmin, request, queryset):

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -31,7 +31,7 @@ import hashlib
 import types
 import sys
 
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.core.exceptions import PermissionDenied, ValidationError
 try:
     from django.urls import reverse

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -68,7 +68,7 @@ def url_to_edit_object(obj):
     url = reverse('admin:%s_%s_change' % (
         obj._meta.app_label, obj._meta.model_name), args=[obj.pk])
     return '<a href="%s" target="_">%s #%s</a>' % (
-        url, obj._meta.model_name, obj.pk)
+        url, obj._meta.verbose_name, obj.pk)
 
 
 def mass_change_selected(modeladmin, request, queryset):

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -304,18 +304,18 @@ class MassAdmin(admin.ModelAdmin):
                                         form,
                                         formset,
                                         change=True)
+                                change_message = self.construct_change_message(
+                                    request,
+                                    form,
+                                    formsets)
+                                self.log_change(
+                                    request,
+                                    new_object,
+                                    change_message)
+                                changed_count += 1
+
                             except DatabaseError as err:
                                 forms_errors.append({new_object: err})
-
-                            change_message = self.construct_change_message(
-                                request,
-                                form,
-                                formsets)
-                            self.log_change(
-                                request,
-                                new_object,
-                                change_message)
-                            changed_count += 1
 
                     if changed_count == objects_count:
                         return self.response_change(request, new_object)

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -315,7 +315,9 @@ class MassAdmin(admin.ModelAdmin):
                                 changed_count += 1
 
                             except DatabaseError as err:
-                                forms_errors.append({new_object: err})
+                                msg = f'<p>Cannot add {new_object}: {err.message}</p>'
+                                messages.add_message(
+                                    request, messages.ERROR, mark_safe(msg))
 
                     if changed_count == objects_count:
                         return self.response_change(request, new_object)

--- a/massadmin/templates/admin/includes/mass_fieldset.html
+++ b/massadmin/templates/admin/includes/mass_fieldset.html
@@ -11,7 +11,7 @@
   <table>
     <tr>
       <th>
-        {% trans "Mass Update?" %}
+        {% trans "Update?" %}
       </th>
       <th>
         {% trans "Field" %}
@@ -50,10 +50,10 @@
             <td class="form-row field-{{ field.field.name }}">
               {% if field.is_checkbox %}
                 <div>{{ field.field }}</div>
-                <div>{{ field.label_tag }}</div>
+                <div>&nbsp;{{ field.label_tag }}</div>
               {% else %}
                 <div>
-                  {{ field.label_tag }}
+                  {{ field.label_tag }}&nbsp;
                 </div>
                 <div>
                   {{ field.field }}

--- a/massadmin/templates/admin/includes/mass_fieldset.html
+++ b/massadmin/templates/admin/includes/mass_fieldset.html
@@ -59,7 +59,9 @@
                   {{ field.field }}
                 </div>
               {% endif %}
-              {% if field.field.field.help_text %}<p class="help">{{ field.field.field.help_text|safe }}</p>{% endif %}
+              {% if field.field.field.help_text %}
+                <p class="help text-help">&nbsp;{{ field.field.field.help_text|safe }}</p>
+              {% endif %}
             </td>
           {% endif %}{% endif %}
         </tr>

--- a/massadmin/templates/admin/includes/mass_fieldset.html
+++ b/massadmin/templates/admin/includes/mass_fieldset.html
@@ -3,11 +3,11 @@
 <fieldset class="grp-module module {{ fieldset.classes }}">
   {% if fieldset.name %}<h2 class="grp-collapse-handler">{{ fieldset.name }} Mass Edit</h2>{% endif %}
   {% if fieldset.description %}<div class="grp-row row"><p class="grp-description">{{ fieldset.description|safe }}</p></div>{% endif %}
-  
+
   {% if general_error %}
     <div class="grp-errors errornote"> {{ general_error}} </div>
   {% endif %}
-  
+
   <table>
     <tr>
       <th>
@@ -25,19 +25,19 @@
           </td>
         </tr>
       {% endif %}
-      
+
       {% for field in line %}
         <tr>
           {% if field.field.name in adminform.readonly_fields %}
             <td>
-              
+
             </td>
             <td>
               {{ field.field.name }} {% trans "is read only." %}
             </td>
           {% else %}{% if field.field.name in unique_fields %}
             <td>
-              
+
             </td>
             <td>
               {{ field.field.name }} {% trans "is unique." %}
@@ -49,7 +49,8 @@
             </td>
             <td class="form-row field-{{ field.field.name }}">
               {% if field.is_checkbox %}
-                {{ field.field }}{{ field.label_tag }}
+                <div>{{ field.field }}</div>
+                <div>{{ field.label_tag }}</div>
               {% else %}
                 <div>
                   {{ field.label_tag }}


### PR DESCRIPTION
It can be difficult for users to see what the underlying problem is when a mass edit fails. Often, its because the data is not correctly supplied to a form. In one case I had, tracking all the form messages allowed me to find an "edge case" in the model's `clean()` function that was preventing the mass edit completing properly.  

The proposed patch does not change any of the core logic but only adds an extra tracking functionality so users can get feedback on any failures via Django's messaging framework.